### PR TITLE
Don't check for HTTP protocol

### DIFF
--- a/youtube/plugin.js
+++ b/youtube/plugin.js
@@ -58,7 +58,7 @@
 												return false;
 											}
 											else
-											if ( this.getValue().length === 0 || this.getValue().indexOf( 'http://' ) === -1 )
+											if ( this.getValue().length === 0 || this.getValue().indexOf( '//' ) === -1 )
 											{
 												alert( editor.lang.youtube.invalidEmbed );
 												return false;


### PR DESCRIPTION
Now YouTube generates code without protocol (src="//www.youtube.com/embed/..."), so this check is incorrect.
