### PR TITLE
removed "," which breaks IE8 and IE9

### DIFF
--- a/youtube/plugin.js
+++ b/youtube/plugin.js
@@ -190,7 +190,7 @@
 											id : 'chkPrivacy',
 											type : 'checkbox',
 											label : editor.lang.youtube.chkPrivacy,
-											'default' : editor.config.youtube_privacy != null ? editor.config.youtube_privacy : false,
+											'default' : editor.config.youtube_privacy != null ? editor.config.youtube_privacy : false
 										},
 										{
 											id : 'txtStartAt',


### PR DESCRIPTION
Would be great if you merge my fix, because the youtube plugin prevented loading the whole CKEditor in IE8/IE9

Regards
   Sven
