### PR TITLE
Added `config.youtube_responsive` in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ Video height:
 config.youtube_height = '480';
 ```
 
+Make responsive (ignore width and height, fit to width):
+
+```js
+config.youtube_responsive = true;
+```
+
 Show related videos:
 
 ```js


### PR DESCRIPTION
The already-working configuration option `youtube_responsive` was missing from documentation in README.md.