### PR TITLE
Fix image source

### DIFF
--- a/youtube/plugin.js
+++ b/youtube/plugin.js
@@ -305,7 +305,7 @@
 							}
 							else
 							if (this.getContentElement('youtubePlugin', 'chkNoEmbed').getValue() === true) {
-								var imgSrc = '//img.youtube.com/vi/' + video + '/sddefault.jpg';
+								var imgSrc = 'https://img.youtube.com/vi/' + video + '/sddefault.jpg';
 								content += '<a href="' + url + '" ><img width="' + width + '" height="' + height + '" src="' + imgSrc + '" '  + responsiveStyle + '/></a>';
 							}
 							else {


### PR DESCRIPTION
Add `https:` to image source generation to allow images to be displayed when viewed in places like email clients. This was done because I have used this plugin in ckeditor to make a nice WYSIWYG interface for sending emails, but if the email comes in with the image and link only, the fact that there is no protocol before the link to the preview image causes it to not display at all. A quick manual edit of the plugin with the change provided here resolved the issue, so I believe it would help the plugin overall.