### PR TITLE
add workflow to publish a release on NPM and on Github Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: publish release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  # publish on NPM registry
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          registry-url: https://registry.npmjs.org/
+      - name: Publish on NPM
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  # create gh release
+  gh-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Generate Changelog
+        uses: scottbrenner/generate-changelog-action@master
+        id: generate_changelog
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          body: |
+             ${{ steps.generate_changelog.outputs.changelog }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a workflow which semplifies the release required work.

When a new tag is pushed a job is launched to automatically publish the new version on NPM.
Another job creates a new release on Github after generating a changelog describing the changes between versions based on the git history.

In order to publish on NPM you need to add a secret called `NPM_TOKEN` in the repository settings.

this closes #90 