### PR TITLE
fix width and height validation

### DIFF
--- a/youtube/plugin.js
+++ b/youtube/plugin.js
@@ -133,9 +133,9 @@
 											'default' : editor.config.youtube_width != null ? editor.config.youtube_width : '640',
 											validate : function () {
 												if (this.getValue()) {
-													var width = parseInt (this.getValue()) || 0;
+													var width = Number(this.getValue());
 
-													if (width === 0) {
+													if (isNaN(width)) {
 														alert(editor.lang.youtube.invalidWidth);
 														return false;
 													}
@@ -154,9 +154,9 @@
 											'default' : editor.config.youtube_height != null ? editor.config.youtube_height : '360',
 											validate : function () {
 												if (this.getValue()) {
-													var height = parseInt(this.getValue()) || 0;
+													var height = Number(this.getValue());
 
-													if (height === 0) {
+													if (isNaN(height)) {
 														alert(editor.lang.youtube.invalidHeight);
 														return false;
 													}


### PR DESCRIPTION
use `Number()` instead of `parseInt()` to validate user input for
height and width properties.
Since `parseInt` stops to the first non-digit and return what it had
parsed so far it allows to enter input such as `640" onload="alert()`

This closes #89

Sorry for the PR flood  :grimacing: 